### PR TITLE
fix: remove invalid align=center from social icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ I work as Director of Technical Evangelism at [Itential](https://itential.com) a
 
 ### Let's Connect
 <p align="left">
-<a href="https://linkedin.com/in/william-collins" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg" alt="william-collins" height="30" width="40" /></a>
-<a href="https://x.com/wcollins502" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/twitter.svg" alt="wcollins502" height="30" width="40" /></a>
-<a href="https://instagram.com/thecloudgambit" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/instagram.svg" alt="thecloudgambit" height="30" width="40" /></a>
-<a href="https://tiktok.com/thecloudgambit" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/tiktok.svg" alt="thecloudgambit" height="30" width="40" /></a>
-<a href="https://wcollins.io" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/rss.svg" alt="blog" height="30" width="40" /></a>
+<a href="https://linkedin.com/in/william-collins" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg" alt="william-collins" height="30" width="40" /></a>
+<a href="https://x.com/wcollins502" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/twitter.svg" alt="wcollins502" height="30" width="40" /></a>
+<a href="https://instagram.com/thecloudgambit" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/instagram.svg" alt="thecloudgambit" height="30" width="40" /></a>
+<a href="https://tiktok.com/thecloudgambit" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/tiktok.svg" alt="thecloudgambit" height="30" width="40" /></a>
+<a href="https://wcollins.io" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/rss.svg" alt="blog" height="30" width="40" /></a>
 </p>


### PR DESCRIPTION
## Description

Removes invalid `align="center"` attribute from social icon `<img>` tags in the Let's Connect section. GitHub's renderer began treating this invalid value as `display: block`, stacking icons vertically.

## Type of Change

- [x] Bug fix

## Changes Made

- Removed `align="center"` from all 5 social icon `<img>` tags in README.md

## Testing

View the rendered README on GitHub — icons should display horizontally side by side.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed