### PR TITLE
feat: modernize profile with dynamic content hub

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,26 @@
+name: Update README with Latest Blog Posts
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme-with-blog:
+    name: Sync latest posts from wcollins.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Pull RSS feed into README
+        uses: gautamkrishnar/blog-post-workflow@master
+        with:
+          feed_list: "https://wcollins.io/index.xml"
+          max_post_count: 5
+          template: "- [$title]($url) <sub>$date</sub>"
+          date_format: "mmm d, yyyy"
+          commit_message: "chore: update latest blog posts"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ I'm Director of Technical Evangelism at [Itential](https://itential.com), host o
 ![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=for-the-badge&logo=ansible&logoColor=white)
 ![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
-![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
 ![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 ![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-<div align="right">
-
-![Profile Views](https://komarev.com/ghpvc/?username=wcollins&style=flat-square&color=58A6FF)
-
-</div>
-
 # Hey, I'm William 👋
 
-[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=58A6FF&center=false&vCenter=true&width=500&lines=Director+of+Technical+Evangelism;Host+of+The+Cloud+Gambit+Podcast;DevOps+%7C+IaC+%7C+NetDevOps)](https://wcollins.io)
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=000000&center=false&vCenter=true&width=600&lines=Builder+%7C+Content+Creator+%7C+Podcaster;Living+at+the+intersection+of+Cloud%2C+Automation%2C+%26+AI)](https://wcollins.io)
 
 I'm Director of Technical Evangelism at [Itential](https://itential.com), host of [The Cloud Gambit Podcast](https://www.thecloudgambit.com), and I write about cloud, automation, and network engineering at [wcollins.io](https://wcollins.io).
 
@@ -20,9 +14,10 @@ I'm Director of Technical Evangelism at [Itential](https://itential.com), host o
 ### 🛠️ Tech Stack
 
 ![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=for-the-badge&logo=ansible&logoColor=white)
+![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
 ![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
-![GitHub](https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 ![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
 ![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white)
@@ -30,48 +25,8 @@ I'm Director of Technical Evangelism at [Itential](https://itential.com), host o
 
 ### 🤝 Let's Connect
 
-<p align="left">
-  <a href="https://linkedin.com/in/william-collins" target="_blank" rel="noopener noreferrer">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/linkedin/white">
-      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/linkedin/0A66C2">
-      <img alt="LinkedIn" src="https://cdn.simpleicons.org/linkedin/0A66C2" height="30" width="30">
-    </picture>
-  </a>
-  &nbsp;
-  <a href="https://x.com/wcollins502" target="_blank" rel="noopener noreferrer">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/x/white">
-      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/x/000000">
-      <img alt="X" src="https://cdn.simpleicons.org/x/000000" height="30" width="30">
-    </picture>
-  </a>
-  &nbsp;
-  <a href="https://instagram.com/thecloudgambit" target="_blank" rel="noopener noreferrer">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/instagram/white">
-      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/instagram/E4405F">
-      <img alt="Instagram" src="https://cdn.simpleicons.org/instagram/E4405F" height="30" width="30">
-    </picture>
-  </a>
-  &nbsp;
-  <a href="https://tiktok.com/thecloudgambit" target="_blank" rel="noopener noreferrer">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/tiktok/white">
-      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/tiktok/FF0050">
-      <img alt="TikTok" src="https://cdn.simpleicons.org/tiktok/FF0050" height="30" width="30">
-    </picture>
-  </a>
-  &nbsp;
-  <a href="https://wcollins.io" target="_blank" rel="noopener noreferrer">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/rss/FFA500">
-      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/rss/FFA500">
-      <img alt="Blog RSS" src="https://cdn.simpleicons.org/rss/FFA500" height="30" width="30">
-    </picture>
-  </a>
-</p>
+<a href="https://linkedin.com/in/william-collins" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/linkedin.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/linkedin.svg?color=%230A66C2"><img alt="LinkedIn" src="https://api.iconify.design/simple-icons/linkedin.svg?color=%230A66C2" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://x.com/wcollins502" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/x.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/x.svg?color=%23000000"><img alt="X" src="https://api.iconify.design/simple-icons/x.svg?color=%23000000" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://instagram.com/thecloudgambit" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/instagram.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/instagram.svg?color=%23E4405F"><img alt="Instagram" src="https://api.iconify.design/simple-icons/instagram.svg?color=%23E4405F" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://tiktok.com/thecloudgambit" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/tiktok.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/tiktok.svg?color=%23FF0050"><img alt="TikTok" src="https://api.iconify.design/simple-icons/tiktok.svg?color=%23FF0050" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://wcollins.io" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/rss.svg?color=%23FFA500"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/rss.svg?color=%23FFA500"><img alt="Blog RSS" src="https://api.iconify.design/simple-icons/rss.svg?color=%23FFA500" height="30" width="30"></picture></a>
 
 ### 🔥 Streak
 
-[![GitHub Streak](https://streak-stats.demolab.com?user=wcollins&theme=dark&hide_border=true)](https://git.io/streak-stats)
+[![GitHub Streak](https://streak-stats.demolab.com?user=wcollins&hide_border=true)](https://git.io/streak-stats)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ I'm Director of Technical Evangelism at [Itential](https://itential.com), host o
 
 ### 🛠️ Tech Stack
 
-![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=for-the-badge&logo=ansible&logoColor=white)
-![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
-![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
-![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
-![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
-![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white)
-![OpenTofu](https://img.shields.io/badge/OpenTofu-FFDA18?style=for-the-badge&logo=opentofu&logoColor=black)
+![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=flat-square&logo=ansible&logoColor=white)
+![Claude](https://img.shields.io/badge/Claude-D97757?style=flat-square&logo=claude&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=flat-square&logo=linux&logoColor=black)
+![Python](https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white)
+![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=flat-square&logo=terraform&logoColor=white)
+![OpenTofu](https://img.shields.io/badge/OpenTofu-FFDA18?style=flat-square&logo=opentofu&logoColor=black)
 
 ### 🤝 Let's Connect
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,77 @@
-### Hello, I'm William :wave:
-I work as Director of Technical Evangelism at [Itential](https://itential.com) and host [The Cloud Gambit Podcast](https://www.thecloudgambit.com).
+<div align="right">
 
-### :hammer_and_wrench: Tech Stack
-![Ansible](https://img.shields.io/badge/Ansible-e93434?&logo=ansible&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-%230db7ed.svg?&logo=docker&logoColor=white)
-![Git](https://img.shields.io/badge/Git-E44C30?&logo=git&logoColor=white)
-![Github](https://img.shields.io/badge/Github-171515?&logo=github&logoColor=white)
-![Linux](https://img.shields.io/badge/Linux-c10017?&logo=linux&logoColor=white)
-![Python](https://img.shields.io/badge/Python-14354C?&logo=python&logoColor=white)
-![Terraform](https://img.shields.io/badge/Terraform-5b4ee4?&logo=terraform&logoColor=white)
-![OpenTofu](https://img.shields.io/badge/OpenTofu-ffda19?&logo=opentofu&logoColor=white)
+![Profile Views](https://komarev.com/ghpvc/?username=wcollins&style=flat-square&color=58A6FF)
 
-### Let's Connect
+</div>
+
+# Hey, I'm William 👋
+
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=58A6FF&center=false&vCenter=true&width=500&lines=Director+of+Technical+Evangelism;Host+of+The+Cloud+Gambit+Podcast;DevOps+%7C+IaC+%7C+NetDevOps)](https://wcollins.io)
+
+I'm Director of Technical Evangelism at [Itential](https://itential.com), host of [The Cloud Gambit Podcast](https://www.thecloudgambit.com), and I write about cloud, automation, and network engineering at [wcollins.io](https://wcollins.io).
+
+### 📝 Latest Content
+
+<!-- BLOG-POST-LIST:START -->
+<!-- BLOG-POST-LIST:END -->
+
+▶ [More on wcollins.io](https://wcollins.io) · 🎙️ [The Cloud Gambit Podcast](https://www.thecloudgambit.com)
+
+### 🛠️ Tech Stack
+
+![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=for-the-badge&logo=ansible&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
+![GitHub](https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
+![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
+![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white)
+![OpenTofu](https://img.shields.io/badge/OpenTofu-FFDA18?style=for-the-badge&logo=opentofu&logoColor=black)
+
+### 🤝 Let's Connect
+
 <p align="left">
-<a href="https://linkedin.com/in/william-collins" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg" alt="william-collins" height="30" width="40" /></a>
-<a href="https://x.com/wcollins502" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/twitter.svg" alt="wcollins502" height="30" width="40" /></a>
-<a href="https://instagram.com/thecloudgambit" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/instagram.svg" alt="thecloudgambit" height="30" width="40" /></a>
-<a href="https://tiktok.com/thecloudgambit" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/tiktok.svg" alt="thecloudgambit" height="30" width="40" /></a>
-<a href="https://wcollins.io" target="blank"><img src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/rss.svg" alt="blog" height="30" width="40" /></a>
+  <a href="https://linkedin.com/in/william-collins" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/linkedin/white">
+      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/linkedin/0A66C2">
+      <img alt="LinkedIn" src="https://cdn.simpleicons.org/linkedin/0A66C2" height="30" width="30">
+    </picture>
+  </a>
+  &nbsp;
+  <a href="https://x.com/wcollins502" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/x/white">
+      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/x/000000">
+      <img alt="X" src="https://cdn.simpleicons.org/x/000000" height="30" width="30">
+    </picture>
+  </a>
+  &nbsp;
+  <a href="https://instagram.com/thecloudgambit" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/instagram/white">
+      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/instagram/E4405F">
+      <img alt="Instagram" src="https://cdn.simpleicons.org/instagram/E4405F" height="30" width="30">
+    </picture>
+  </a>
+  &nbsp;
+  <a href="https://tiktok.com/thecloudgambit" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/tiktok/white">
+      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/tiktok/FF0050">
+      <img alt="TikTok" src="https://cdn.simpleicons.org/tiktok/FF0050" height="30" width="30">
+    </picture>
+  </a>
+  &nbsp;
+  <a href="https://wcollins.io" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/rss/FFA500">
+      <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/rss/FFA500">
+      <img alt="Blog RSS" src="https://cdn.simpleicons.org/rss/FFA500" height="30" width="30">
+    </picture>
+  </a>
 </p>
+
+### 🔥 Streak
+
+[![GitHub Streak](https://streak-stats.demolab.com?user=wcollins&theme=dark&hide_border=true)](https://git.io/streak-stats)


### PR DESCRIPTION
## Description

Replaces the profile README with a content-hub layout (typing SVG, RSS-driven Latest Content, picture-element social icons, for-the-badge tech stack, streak stats, profile views) and adds a daily GitHub Actions workflow that syncs the latest posts from `wcollins.io`.

## Type of Change

- [x] New feature

## Changes Made

- Profile views badge, typing SVG header, and intro
- Latest Content section with `BLOG-POST-LIST:START/END` markers
- Tech stack rebuilt with `for-the-badge` style and brand colors
- Social icons rewritten with `<picture>` for dark/light variants and `target="_blank" rel="noopener noreferrer"`
- Streak stats card linked to git.io/streak-stats
- New workflow at `.github/workflows/update-readme.yml` running daily at 06:00 UTC + manual dispatch, pulling from `https://wcollins.io/index.xml`

## Testing

- Verified RSS feed URL (`/index.xml`) returns RSS 2.0; the other candidates (`/feed.xml`, `/rss.xml`, `/feed/`, `/atom.xml`) all 404
- Confirmed no `align="center"`, no `simple-icons@3.0.1` jsdelivr URLs, and no `target="blank"` (missing underscore) remain
- After merge: trigger the workflow manually from the Actions tab to verify the first RSS sync commits successfully

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #3