### PR TITLE
fix: scope blog feed to posts section

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Pull RSS feed into README
         uses: gautamkrishnar/blog-post-workflow@master
         with:
-          feed_list: "https://wcollins.io/index.xml"
+          feed_list: "https://wcollins.io/posts/index.xml"
           max_post_count: 5
           template: "- [$title]($url) <sub>$date</sub>"
           date_format: "mmm d, yyyy"


### PR DESCRIPTION
## Description

The `update-readme.yml` workflow was failing with `Cannot read response->item->link`. Switching the feed URL from the site-wide `/index.xml` to `/posts/index.xml` lets the action parse the feed end-to-end.

## Type of Change

- [x] Bug fix

## Root Cause

`https://wcollins.io/index.xml` aggregates every Hugo content section: blog posts, talks, events, links, and the projects page. Many of those non-post entries have no `<link>` element. `gautamkrishnar/blog-post-workflow` aborts the entire run on the first item missing a `<link>`, so it never reached the actual blog posts.

## Fix

One-line change: point `feed_list` at Hugo's per-section feed for `/posts/`. That feed contains only items from the posts directory, all of which have valid `<link>` elements.

## Verification

- `curl https://wcollins.io/posts/index.xml` returns 39 items, every one with a `<link>` element (XPath check: `//item[not(link) or normalize-space(link)='']` returns empty set)
- After merge: trigger the workflow manually from the Actions tab and confirm the Latest Content section in the README populates with the 5 most recent posts

## Alternatives Considered

The action's maintainer suggests `disable_item_validation: true` + `item_exec` to skip bad items. That would still pull every talk/event into the parser pipeline before discarding them. Filtering at the source URL is simpler and faster.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed