### PR TITLE
style: shrink typing svg font to fit AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hey, I'm William 👋
 
-[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=000000&center=false&vCenter=true&width=600&lines=Builder+%7C+Content+Creator+%7C+Podcaster;Living+at+the+intersection+of+Cloud%2C+Automation%2C+%26+AI)](https://wcollins.io)
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&size=18&pause=1000&color=000000&center=false&vCenter=true&width=600&lines=Builder+%7C+Content+Creator+%7C+Podcaster;Living+at+the+intersection+of+Cloud%2C+Automation%2C+%26+AI)](https://wcollins.io)
 
 I'm Director of Technical Evangelism at [Itential](https://itential.com), host of [The Cloud Gambit Podcast](https://www.thecloudgambit.com), and I write about cloud, automation, and network engineering at [wcollins.io](https://wcollins.io).
 


### PR DESCRIPTION
## Description

The second typing-SVG line ("Living at the intersection of Cloud, Automation, & AI") was being clipped at "AI" because the default font size (20) overflowed the 600px SVG width. Adding `size=18` shrinks the text just enough so the full line renders.

## Type of Change

- [x] Style / cosmetic fix

## Changes Made

- Add `size=18` query parameter to the `readme-typing-svg.demolab.com` URL in `README.md`

## Why size=18 (not narrower width or wider SVG)

- The longest line is 53 chars; at the default size 20 in Fira Code monospace it needs ~636px, so 600px clipped the tail
- At size 18 the same line needs ~572px — fits with headroom
- Kept width at 600 to avoid pushing the SVG past the comfortable column width on the GitHub profile page

## Testing

- View the rendered profile at https://github.com/wcollins after merge — the second typing line should display "AI" fully, not clipped

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed