### PR TITLE
style: set streak-stats theme to dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ I'm Director of Technical Evangelism at [Itential](https://itential.com), host o
 
 ### 🔥 Streak
 
-[![GitHub Streak](https://streak-stats.demolab.com?user=wcollins&hide_border=true)](https://git.io/streak-stats)
+[![GitHub Streak](https://streak-stats.demolab.com?user=wcollins&theme=dark&hide_border=true)](https://git.io/streak-stats)


### PR DESCRIPTION
## Description

Switch the GitHub Streak card theme to dark for a consistent look in the README.

## Type of Change

- [x] Style

## Changes Made

- Added `theme=dark` query parameter to the streak-stats URL

## Testing

- Open the README on GitHub and confirm the streak card renders in the dark theme

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed