### PR TITLE
style: remove emojis from section headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 I'm Director of Technical Evangelism at [Itential](https://itential.com), host of [The Cloud Gambit Podcast](https://www.thecloudgambit.com), and I write about cloud, automation, and network engineering at [wcollins.io](https://wcollins.io).
 
-### 🛠️ Tech Stack
+### Tech Stack
 
 ![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=flat-square&logo=ansible&logoColor=white)
 ![Claude](https://img.shields.io/badge/Claude-D97757?style=flat-square&logo=claude&logoColor=white)
@@ -19,6 +19,6 @@ I'm Director of Technical Evangelism at [Itential](https://itential.com), host o
 
 <a href="https://linkedin.com/in/william-collins" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/linkedin.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/linkedin.svg?color=%23000000"><img alt="LinkedIn" src="https://api.iconify.design/simple-icons/linkedin.svg?color=%23000000" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://x.com/wcollins502" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/x.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/x.svg?color=%23000000"><img alt="X" src="https://api.iconify.design/simple-icons/x.svg?color=%23000000" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://instagram.com/thecloudgambit" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/instagram.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/instagram.svg?color=%23000000"><img alt="Instagram" src="https://api.iconify.design/simple-icons/instagram.svg?color=%23000000" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://tiktok.com/thecloudgambit" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/tiktok.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/tiktok.svg?color=%23000000"><img alt="TikTok" src="https://api.iconify.design/simple-icons/tiktok.svg?color=%23000000" height="30" width="30"></picture></a>&nbsp;&nbsp;<a href="https://wcollins.io" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.iconify.design/simple-icons/rss.svg?color=white"><source media="(prefers-color-scheme: light)" srcset="https://api.iconify.design/simple-icons/rss.svg?color=%23000000"><img alt="Blog RSS" src="https://api.iconify.design/simple-icons/rss.svg?color=%23000000" height="30" width="30"></picture></a>
 
-### 🔥 Streak
+### Streak
 
 [![GitHub Streak](https://streak-stats.demolab.com?user=wcollins&theme=dark&hide_border=true)](https://git.io/streak-stats)


### PR DESCRIPTION
## Description

Removes the emojis from the Tech Stack and Streak section headings for a cleaner look. The Let's Connect heading is unchanged.

## Type of Change

- [x] Style

## Changes Made

- Drop the wrench emoji from the Tech Stack heading
- Drop the fire emoji from the Streak heading

## Testing

View the profile README on GitHub and confirm the two headings render as plain text.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed